### PR TITLE
Remove the Extra Environments

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       all-dependencies:
         patterns:
           - '*'
+    # Ignore dependency patches
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -14,9 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    environment:
-      name: ${{ github.ref_name != 'main' && 'testing' || 'unrestricted' }}
-
     steps:
     - uses: actions/checkout@v4
       with:
@@ -66,9 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    environment:
-      name: ${{ github.ref_name != 'main' && 'testing' || 'unrestricted' }}
-
     steps:
     - uses: actions/checkout@v4
 
@@ -89,9 +83,6 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
-    environment:
-      name: ${{ github.ref_name != 'main' && 'testing' || 'unrestricted' }}
 
     steps:
     - uses: actions/checkout@v4
@@ -121,9 +112,6 @@ jobs:
             triple: aarch64-apple-darwin
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     timeout-minutes: 30
-
-    environment:
-      name: ${{ github.ref_name != 'main' && 'testing' || 'unrestricted' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -18,9 +18,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    environment:
-      name: ${{ github.ref_name != 'main' && 'testing' || 'unrestricted' }}
-
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
It turns out I misunderstood the GitHub CI-approval model and these environments are not necessary to prevent third parties from triggering our CI.